### PR TITLE
Resolve Elixir 1.11 compilation warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,12 @@ defmodule Puid.Mixfile do
     ]
   end
 
+  def application do
+    [
+      extra_applications: [:crypto]
+    ]
+  end
+
   defp deps do
     [
       {:crypto_rand, "~> 1.0"},


### PR DESCRIPTION
This adds `extra_applications` to mix.exs, referencing the required
:crypto dependency

Resolves Issue #6 