### PR TITLE
Set default for Process.get to empty bitstring

### DIFF
--- a/lib/puid/bits.ex
+++ b/lib/puid/bits.ex
@@ -66,8 +66,6 @@ defmodule Puid.Bits do
       @puid_len puid_len
       @puid_rand_bytes rand_bytes
 
-      Process.put(@puid_carried_bits, <<>>)
-
       # If chars count is a power of 2, sliced bits always yield a valid char
       is_pow2? = pow2?(chars_count)
 
@@ -79,7 +77,7 @@ defmodule Puid.Bits do
         is_pow2? ->
           # Sliced bits always valid with carried bits
           def generate() do
-            carried_bits = Process.get(@puid_carried_bits)
+            carried_bits = Process.get(@puid_carried_bits, <<>>)
 
             <<puid_bits::size(@puid_bits_per_puid), unused_bits::bits>> =
               generate_bits(@puid_len, carried_bits)
@@ -91,7 +89,7 @@ defmodule Puid.Bits do
 
         true ->
           # Always manage carried bits since bit slices can be rejected with variable sift
-          def generate(), do: generate(@puid_len, Process.get(@puid_carried_bits), <<>>)
+          def generate(), do: generate(@puid_len, Process.get(@puid_carried_bits, <<>>), <<>>)
 
           defp generate(0, unused_bits, puid_bits) do
             Process.put(@puid_carried_bits, unused_bits)


### PR DESCRIPTION
It is not always the case that the process that `use`s Puid is the one to call `generate/0`. When this happens, the `@puid_carried_bits` key in the process dictionary is not going to be set, and we end up calling `bit_size(nil)`, which crashes. Instead of trying to set the key when the module is built, just use `<<>>` as the default value, which works for every process.

Fixes #10.