### PR TITLE
Fix bit shift pattern matching in bits.ex

### DIFF
--- a/lib/puid/bits.ex
+++ b/lib/puid/bits.ex
@@ -166,7 +166,7 @@ defmodule Puid.Bits do
 
           # IO.puts("reject #{value} --> #{bit_shift}")
 
-          <<_used::size(bit_shift), rest::bits>> = bits
+          <<_used::size(^bit_shift), rest::bits>> = bits
 
           slice(
             count - 1,


### PR DESCRIPTION
Fiixes compilation warning on Elixir 1.20.0-rc.0

```zsh
Generated puid app
==> yui
Compiling 61 files (.ex)
    warning: the variable "bit_shift" (context Puid.Bits) is accessed inside size(...) of a bitstring but it was defined outside of the match. You must precede it with the pin operator
    │
  3 │   use Puid, bits: 140
    │   ~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/yui/encryption/puid.ex:3: Yui.Encryption.PUID.Bits.slice/4
```